### PR TITLE
✨ Feat: RefreshToken 만료 시 예외 처리 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ gradlew.bat
 
 src/main/resources/application-dev.properties
 src/main/resources/application-prod.properties
+src/main/resources/application-h2.properties
 
 ### properties about security key ###
 security.properties

--- a/src/main/java/com/sparta/soundsea/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/sparta/soundsea/common/exception/ExceptionMessage.java
@@ -2,8 +2,6 @@ package com.sparta.soundsea.common.exception;
 
 import lombok.Getter;
 
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 @Getter
 public enum ExceptionMessage {
 
@@ -22,7 +20,7 @@ public enum ExceptionMessage {
     TOKEN_NOT_FOUND_MSG(401,"토큰이 존재하지 않습니다."),
     INVALID_TOKEN_MSG(401,"토큰이 유효하지 않습니다."),
 
-    REFRESH_TOKEN_NOT_FOUND_MSG(401, "로그아웃 된 사용자입니다"),
+    REFRESH_TOKEN_NOT_FOUND_MSG(401, "로그아웃된 사용자입니다."),
     UNAUTHORIZED_USER(403, "인가되지 않은 사용자입니다"),
 
     // 403 토큰 만료

--- a/src/main/java/com/sparta/soundsea/common/response/ResponseMessage.java
+++ b/src/main/java/com/sparta/soundsea/common/response/ResponseMessage.java
@@ -14,7 +14,7 @@ public enum ResponseMessage {
     COMMENT_UPDATE_SUCCESS_MSG(200, "댓글 수정 성공"),
 
 
-    COMMENT_DELETE_SUCCESS_MSG(200, "댓글 삭제 성공");
+    COMMENT_DELETE_SUCCESS_MSG(200, "댓글 삭제 성공"),
 
 
     READ_MUSIC_ALL_SUCCESS_MSG(200, "추천 음악 전체 조회 성공"),

--- a/src/main/java/com/sparta/soundsea/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/sparta/soundsea/security/jwt/JwtAuthFilter.java
@@ -50,11 +50,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         // 2. Token 유효성 검사 및 인증
         // 2-1. Token 존재 여부 확인
         if(token == null) {
-            throw new CustomSecurityException(INVALID_TOKEN_MSG);
+            throw new CustomSecurityException(TOKEN_NOT_FOUND_MSG);
         }
         // 2-2. Token 유효성 확인
         if(!jwtUtil.validateAccessToken(token, request, response)){
-            throw new CustomSecurityException(TOKEN_NOT_FOUND_MSG);
+            throw new CustomSecurityException(INVALID_TOKEN_MSG);
         }
         // 3. 사용자 인증
         Claims info = jwtUtil.getUserInfoFromHttpServletRequest(request);

--- a/src/main/java/com/sparta/soundsea/security/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/soundsea/security/jwt/JwtUtil.java
@@ -26,6 +26,7 @@ import java.util.Date;
 
 import static com.sparta.soundsea.common.exception.ExceptionMessage.TOKEN_NOT_FOUND_MSG;
 import static com.sparta.soundsea.common.exception.ExceptionMessage.USER_NOT_FOUND_ERROR_MSG;
+import static com.sparta.soundsea.common.exception.ExceptionMessage.REFRESH_TOKEN_NOT_FOUND_MSG;
 
 @Slf4j      // Console에 log 찍으려고 사용
 @Component  // Bean 등록
@@ -168,14 +169,15 @@ public class JwtUtil {
         if (user.getAccessToken().substring(7).equals(resolveToken(request, "AccessToken"))
                 && user.getRefreshToken().substring(7).equals(resolveToken(request, "RefreshToken"))){
             // 4. RefreshToken 유효성 검사
-            if (validateRefreshToken(resolveToken(request, "RefreshToken"))){
-                System.out.println("JWT 재발급 조건 충족");
-                String newAccessToken = createAccessToken(user.getLoginId(), user.getRole());
-                response.addHeader(JwtUtil.AUTHORIZATION_ACCESS, newAccessToken);
-                // 5. Member Data 최신화
-                user.updateToken(newAccessToken, user.getRefreshToken());
-                userRepository.save(user);
+            if(!validateRefreshToken(resolveToken(request, "RefreshToken"))){
+                throw new CustomSecurityException(REFRESH_TOKEN_NOT_FOUND_MSG);
             }
+            System.out.println("JWT 재발급 조건 충족");
+            String newAccessToken = createAccessToken(user.getLoginId(), user.getRole());
+            response.addHeader(JwtUtil.AUTHORIZATION_ACCESS, newAccessToken);
+            // 5. Member Data 최신화
+            user.updateToken(newAccessToken, user.getRefreshToken());
+            userRepository.save(user);
         }
         // 6. 로그인 페이지 반환
     }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
RefreshToken 만료 시 예외 처리 추가하였습니다.
기존에는 RefreshToken과 AccessToken 만료 관련 메세지를 동일하게 처리하였습니다.
동일하게 처리할 경우 FE에서 RefreshToken 만료 시, 유저를 로그인 페이지로 이동시키기 어려울 것 같아, Exception을 새로 추가하였습니다.


## 작업사항
- RefreshToken Exception 추가


## 변경로직
- RefreshToken의 유효성을 검사하고, 검사 결과 이상이 있을 경우 예외 처리 되도록 변경

## 참고사항
1. RefreshToken 관련 매커니즘
![image](https://user-images.githubusercontent.com/72681875/208338341-e27bc14b-f5e7-496d-8336-5e9a0cca7928.png)

3. RefreshToken 관련 매니저님 문의 결과
![image](https://user-images.githubusercontent.com/72681875/208338308-d9cea5ef-5365-4d3c-99e6-bec144d1a454.png)

close #36 
